### PR TITLE
Don’t reset cookie data after submit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,8 @@ Webform tracking
 ================
 
 ...collects data about your users and associates it with their
-[webform](https://drupal.org/project/webform) submissions. It uses
-[session_cache](https://drupal.org/project/session_cache) and `hook_boot` to
-avoid interference with Drupals page cache. If you want to actually see the
-resulting data you need to apply the patch in
+[webform](https://drupal.org/project/webform) submissions. If you want to
+actually see the resulting data you need to apply the patch in
 [#2117285](https://drupal.org/node/2117285), to webform (or implement a better
 solution ;))
 

--- a/src/Extractor.php
+++ b/src/Extractor.php
@@ -101,6 +101,12 @@ class Extractor {
     ];
   }
 
+  /**
+   * Save tracking variables for a submission.
+   *
+   * @return array
+   *   The updated cookie data.
+   */
   public function saveVars($submission) {
     $cookie_data = $this->cookieData + [
       'history' => [],
@@ -123,6 +129,7 @@ class Extractor {
     $submission->tracking = (object) $data;
 
     db_insert('webform_tracking')->fields($data)->execute();
-    return $parameters['user_id'];
+    $cookie_data['user_id'] = $parameters['user_id'];
+    return $cookie_data;
   }
 }

--- a/webform_tracking.module
+++ b/webform_tracking.module
@@ -53,16 +53,14 @@ function webform_tracking_init() {
 /**
  * Implements hook_webform_submission_insert().
  *
- * Save tracking data along with the submission. Reset the cookie content.
+ * Save tracking data along with the submission and update the cookie content.
  */
 function webform_tracking_webform_submission_insert($node, $submission) {
-  $user_id = Extractor::fromEnv()->saveVars($submission);
-  // Set user_id cookie if possible. hook_webform_submission_insert() can be
+  $cookie = Extractor::fromEnv()->saveVars($submission);
+  // Set new cookie data if possible. hook_webform_submission_insert() can be
   // triggered in all kinds of situations not only on form submits.
   if (!headers_sent()) {
-    setcookie('webform_tracking', drupal_json_encode([
-      'user_id' => $user_id,
-    ]), 0, '/');
+    setcookie('webform_tracking', drupal_json_encode($cookie), 0, '/');
   }
 }
 


### PR DESCRIPTION
→ Only add the user_id if possible.