### PR TITLE
Options for anonymized ip address recording.

### DIFF
--- a/tests/AnonymizeTrackingTest.php
+++ b/tests/AnonymizeTrackingTest.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\webform_tracking;
+
+/**
+ * Test newsletter subscription activities related to IP addresses.
+ */
+class AnonymizeTrackingTest extends \DrupalWebTestCase {
+
+  /**
+   * Set up.
+   */
+  public function setUp() {
+    $this->oldserver = $_SERVER;
+    $this->remote_ip = '127.210.33.7';
+    drupal_static_reset('ip_address');
+    // @codingStandardsIgnoreLine
+    $_SERVER['REMOTE_ADDR'] = $this->remote_ip;
+
+    // Defaults for variable_get.
+    $GLOBALS['conf']['webform_tracking_track_ip_address'] = FALSE;
+    $GLOBALS['conf']['webform_tracking_significant_ip_address_bits'] = 16;
+
+    parent::setUp();
+
+    db_delete('webform_tracking')->execute();
+  }
+
+  /**
+   * Tear down.
+   */
+  public function tearDown() {
+    $_SERVER = $this->oldserver;
+    drupal_static_reset('ip_address');
+
+    parent::tearDown();
+
+    db_delete('webform_tracking')->execute();
+  }
+
+  /**
+   * The Extractor writes a record.
+   */
+  public function testExtractor() {
+    $submission = array(
+      'nid' => 1,
+      'sid' => 1,
+    );
+    $cookie = Extractor::fromEnv()->saveVars((object) $submission);
+
+    $count = db_select('webform_tracking')
+      ->condition('nid', 1)
+      ->condition('sid', 1)
+      ->countQuery()->execute()->fetchField();
+    $this->assertEqual(1, $count);
+  }
+
+  /**
+   * By default no IP address is stored.
+   */
+  public function testTrackingDisabledByDefault() {
+    $submission = array(
+      'nid' => 1,
+      'sid' => 1,
+    );
+    $cookie = Extractor::fromEnv()->saveVars((object) $submission);
+
+    $tracking = db_select('webform_tracking', 't')
+      ->fields('t')
+      ->condition('nid', 1)
+      ->condition('sid', 1)
+      ->execute()->fetch();
+
+    // Empty string means disabled.
+    $this->assertEqual('', $tracking->ip_address);
+  }
+
+  /**
+   * Enabled tracking with a bitmask.
+   */
+  public function testTrackingEnabledWithDefaultMask() {
+    $GLOBALS['conf']['webform_tracking_track_ip_address'] = TRUE;
+
+    $submission = array(
+      'nid' => 1,
+      'sid' => 1,
+    );
+    $cookie = Extractor::fromEnv()->saveVars((object) $submission);
+
+    $tracking = db_select('webform_tracking', 't')
+      ->fields('t')
+      ->condition('nid', 1)
+      ->condition('sid', 1)
+      ->execute()->fetch();
+
+    $this->assertEqual('127.210.0.0', $tracking->ip_address);
+  }
+
+  /**
+   * Enabled tracking with a specified bitmask.
+   */
+  public function testTrackingEnabledWithCustomMask() {
+    $GLOBALS['conf']['webform_tracking_track_ip_address'] = TRUE;
+    $GLOBALS['conf']['webform_tracking_significant_ip_address_bits'] = 6;
+
+    $submission = array(
+      'nid' => 1,
+      'sid' => 1,
+    );
+    $cookie = Extractor::fromEnv()->saveVars((object) $submission);
+
+    $tracking = db_select('webform_tracking', 't')
+      ->fields('t')
+      ->condition('nid', 1)
+      ->condition('sid', 1)
+      ->execute()->fetch();
+
+    $this->assertEqual('124.0.0.0', $tracking->ip_address);
+  }
+
+  /**
+   * Track the full IP address.
+   */
+  public function testTrackingEnabledWithFullAddress() {
+    $GLOBALS['conf']['webform_tracking_track_ip_address'] = TRUE;
+    $GLOBALS['conf']['webform_tracking_significant_ip_address_bits'] = 32;
+
+    $submission = array(
+      'nid' => 1,
+      'sid' => 1,
+    );
+    $cookie = Extractor::fromEnv()->saveVars((object) $submission);
+
+    $tracking = db_select('webform_tracking', 't')
+      ->fields('t')
+      ->condition('nid', 1)
+      ->condition('sid', 1)
+      ->execute()->fetch();
+
+    $this->assertEqual('127.210.33.7', $tracking->ip_address);
+  }
+
+}

--- a/webform_tracking.module
+++ b/webform_tracking.module
@@ -26,6 +26,19 @@ function webform_tracking_form_webform_admin_settings_alter(&$form, &$form_state
     '#default_value' => variable_get('webform_tracking_respect_dnt', TRUE),
   );
 
+  $form['webform_tracking']['webform_tracking_track_ip_address'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Record the IP address'),
+    '#default_value' => variable_get('webform_tracking_track_ip_address', FALSE),
+  );
+
+  $form['webform_tracking']['webform_tracking_significant_ip_address_bits'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Significant bits in anonymized IP addresses'),
+    '#description' => t('Use a range of 0 to 32. 0 meaning that 0.0.0.0 is the only IP address every recorded, 16 meaning the first "half" of the IP address is recorded, and 32 meaning the full IP address is recorded. This is supposed to only work with IPv4.'),
+    '#default_value' => variable_get('webform_tracking_significant_ip_address_bits', 16),
+  );
+
   array_unshift($form['#submit'], 'webform_tracking_webform_admin_settings_submit');
 }
 
@@ -34,6 +47,12 @@ function webform_tracking_form_webform_admin_settings_alter(&$form, &$form_state
  */
 function webform_tracking_webform_admin_settings_submit(&$form, &$form_state) {
   variable_set('webform_tracking_respect_dnt', $form_state['values']['webform_tracking_respect_dnt']);
+  variable_set('webform_tracking_track_ip_address', $form_state['values']['webform_tracking_track_ip_address']);
+  // cast to a number, update the form_state so that submit handlers after us
+  // see the same value
+  $bits = (int) $form_state['values']['webform_tracking_significant_ip_address_bits'];
+  $form_state['values']['webform_tracking_significant_ip_address_bits'] = $bits;
+  variable_set('webform_tracking_significant_ip_address_bits', $bits);
 }
 
 /**


### PR DESCRIPTION
- anonymize IP after country was detected
- if tracking is disabled, an empty string is saved
- if enabled the significant bits can be configured
- NB: the defaults have changed:
  * by default NO tracking is done
  * if IP address tracking is enabled, only the first 16 bits get
    recorded